### PR TITLE
Modified add_to_base methods.

### DIFF
--- a/app/models/gw/schedule_repeat.rb
+++ b/app/models/gw/schedule_repeat.rb
@@ -665,7 +665,7 @@ class Gw::ScheduleRepeat < Gw::Database
         _uid = _user[1]
         _u = System::User.where(state: 'enabled', id: _uid, code: AppConfig.gw.schedule_pref_admin['pref_admin_code']).first
         if !_u.blank?
-          item.errors.add_to_base '「全庁予定」が参加者として選択されているが，「公開（誰でも閲覧可）」となっていません。'
+          item.errors.add :base, '「全庁予定」が参加者として選択されているが，「公開（誰でも閲覧可）」となっていません。'
         end
       end
     end

--- a/app/models/gw/todo.rb
+++ b/app/models/gw/todo.rb
@@ -19,7 +19,7 @@ class Gw::Todo < Gw::Database
   end
 
   def validate_count
-    errors.add_to_base 'ToDoは２００件以上登録することができません。' if self.class.get_count >= 200 && self.new_record?
+    errors.add :base, 'ToDoは２００件以上登録することができません。' if self.class.get_count >= 200 && self.new_record?
   end
 
   def validate_ed_at

--- a/app/models/questionnaire/form_field.rb
+++ b/app/models/questionnaire/form_field.rb
@@ -158,7 +158,7 @@ private
       else
         current = self.class.where(["parent_id = ? AND id != ? AND state = ?",self.parent_id, self.id,"public"]).count
       end
-      self.errors.add_to_base "設問数は64問以内で作成してください。" unless current < 64
+      self.errors.add :base, "設問数は64問以内で作成してください。" unless current < 64
     end
   end
 

--- a/app/models/questionnaire/template_form_field.rb
+++ b/app/models/questionnaire/template_form_field.rb
@@ -214,7 +214,7 @@ private
       else
         current = Questionnaire::TemplateFormField.where(["parent_id = ? AND id != ? AND state = ?",self.parent_id, self.id,"public"]).count
       end
-      self.errors.add_to_base "設問数は64問以内で作成してください。" unless current < 64
+      self.errors.add :base, "設問数は64問以内で作成してください。" unless current < 64
     end
   end
 

--- a/app/models/system/role_developer.rb
+++ b/app/models/system/role_developer.rb
@@ -64,7 +64,7 @@ private
    if errors.invalid?(:role_name_id)
       unless self.role_name_id.blank?
         errors.clear
-        errors.add_to_base('すでに登録済です。')
+        errors.add(:base, 'すでに登録済です。')
         errors.add_on_blank(:idx)
         errors.add(:idx, 'は数値で入力してください。') unless idxisnum
       end


### PR DESCRIPTION
Rails 3.0.0 時に非推奨となったメソッドが残っておりました。
Rials ４系では存在しないメソッドです。修正したので、ご確認ください。

sb01_training_schedule.rb にもメソッドがありましたが、コメント部分でしたので、修正はしておりません。
[app/models/gwsub/sb01_training_schedule.rb#L28 ](https://github.com/joruri/joruri-gw/blob/master/app/models/gwsub/sb01_training_schedule.rb#L28)

---

* ActiveRecord::Errors#add_to_base(msg) has been deprecated, use Errors#add(:base, msg) instead.
 * refs [Rails v3.0.0 ActiveModel::DeprecatedErrorMethods](https://github.com/rails/rails/blob/v3.0.0/activemodel/lib/active_model/deprecated_error_methods.rb#L18)
* The Last existing version is v2.3.8.
 * refs [Rails v2.3.8 ActiveRecord::Errors](https://github.com/rails/rails/blob/v2.3.8/activerecord/lib/active_record/validations.rb#L150)