### PR TITLE
modify personel class width

### DIFF
--- a/public/_common/themes/gw/css/common_classes_gw.css
+++ b/public/_common/themes/gw/css/common_classes_gw.css
@@ -37,7 +37,7 @@
 }
 #headerBody .personal {
   float: left;
-  width: 42%;
+  max-width: 42%;
   line-height: 55px;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
div.personal を text-overflow させる必要がない場合は同要素の横幅を縮めてほしいです。
(本質的対応ではありませんが) 多くのシーンで cms.header_link を起因とするカラム落ちを救済できると考えます。

![fix](https://cloud.githubusercontent.com/assets/141510/11059186/8677b1b0-87db-11e5-9480-fa262dfdfad7.png)

現行仕様では cms.header_link から追加できる任意要素の横幅が約63pxを超えると、ブラウザ横幅が最小(980px) の時にカラム落ちが発生してします。 

![4](https://cloud.githubusercontent.com/assets/141510/11059117/0ba0b63a-87db-11e5-8ac9-b7261bb1218e.png)
